### PR TITLE
🐞fix: fix `shape.label` is none caused by label_dialog return empty s…

### DIFF
--- a/anylabeling/views/labeling/label_widget.py
+++ b/anylabeling/views/labeling/label_widget.py
@@ -2533,6 +2533,7 @@ class LabelmeWidget(LabelDialog):
         )
         if not text:
             self.label_dialog.edit.setText(previous_text)
+            return
 
         if not self.validate_label(text):
             self.error_message(


### PR DESCRIPTION
In auto labeling mode. 
When you press ESC while labeling, an empty string will be returned.

![CleanShot_2023-04-20_at_15 47 18@2x](https://user-images.githubusercontent.com/31334545/233301715-b080b0cd-d189-48fe-a42d-23464812a613.png)


`Traceback (most recent call last):
  File ".../anylabeling/anylabeling/views/labeling/label_widget.py", line 2566, in finish_auto_labeling_object
    self.unique_label_list.set_item_label(

  File ".../anylabeling/anylabeling/views/labeling/widgets/unique_label_qlist_widget.py", line 38, in set_item_label
    html.escape(label), *color

  File "/opt/homebrew/anaconda3/envs/anylabeling/lib/python3.8/html/__init__.py", line 19, in escape
    s = s.replace("&", "&amp;") # Must be done first!

AttributeError: 'NoneType' object has no attribute 'replace'`