### PR TITLE
✨ feat: split shape into two parts.

### DIFF
--- a/anylabeling/views/labeling/shape.py
+++ b/anylabeling/views/labeling/shape.py
@@ -131,6 +131,12 @@ class Shape:
         """Remove point from a specific index"""
         self.points.pop(i)
 
+    def get_points(self):
+        return self.points
+
+    def replace_points(self, lst):
+        self.points = lst
+
     def is_closed(self):
         """Check if the shape is closed"""
         return self._closed


### PR DESCRIPTION
# Application scenario 
> In the process of using one's own model for segmentation, boundaries may sometimes be connected together and need to be cut off. However, the results may not be ideal when adjusted through negative points.

# Example 
## Case
> For example, the following image is marked:
![example](https://user-images.githubusercontent.com/31334545/233976663-71ab0b74-238f-4fed-8bf5-65043f34e50a.png)
In this case, manually segmenting the previous results can quickly achieve satisfactory results

## Split Result
> ![Result](https://user-images.githubusercontent.com/31334545/233978948-5296d637-5b8c-42da-9c6e-aac9568aa670.png)

# Usage
In edit mode, hold down `Alt` and click `LeftButton` on the two points you want to split in sequence.


# Format & check
> ![format](https://user-images.githubusercontent.com/31334545/233979956-ed629bf7-55d4-44f7-8e37-cfdd6ddcce21.png)
>> There are many branches here, perhaps we can consider refactoring them.
![function-mousePressEvent@2x](https://user-images.githubusercontent.com/31334545/233981056-6e917e8e-400f-4dbc-b780-ada06371648b.png)

