### PR TITLE
add more schortcuts

### DIFF
--- a/anylabeling/configs/anylabeling_config.yaml
+++ b/anylabeling/configs/anylabeling_config.yaml
@@ -111,6 +111,7 @@ shortcuts:
   remove_selected_point: Backspace
   group_selected_shapes: G
   ungroup_selected_shapes: U
+  toggle_auto_use_last_label: Ctrl+Y
 
   auto_label: Ctrt+A
 

--- a/anylabeling/views/labeling/label_widget.py
+++ b/anylabeling/views/labeling/label_widget.py
@@ -354,7 +354,7 @@ class LabelingWidget(LabelDialog):
         toggle_auto_use_last_label_mode = action(
             self.tr("Auto Use Last Label"),
             self.toggle_auto_use_last_label,
-            None,
+            shortcuts["toggle_auto_use_last_label"],
             None,
             self.tr('Toggle "Auto Use Last Label" mode'),
             checkable=True,

--- a/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.py
+++ b/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.py
@@ -64,11 +64,13 @@ class AutoLabelingWidget(QWidget):
                 AutoLabelingMode.ADD, AutoLabelingMode.POINT
             )
         )
+        self.button_add_point.setShortcut("Q")
         self.button_remove_point.clicked.connect(
             lambda: self.set_auto_labeling_mode(
                 AutoLabelingMode.REMOVE, AutoLabelingMode.POINT
             )
         )
+        self.button_remove_point.setShortcut("E")
         self.button_add_rect.clicked.connect(
             lambda: self.set_auto_labeling_mode(
                 AutoLabelingMode.ADD, AutoLabelingMode.RECTANGLE

--- a/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.ui
+++ b/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.ui
@@ -109,14 +109,14 @@
      <item>
       <widget class="QPushButton" name="button_add_point">
        <property name="text">
-        <string>+Point</string>
+        <string>+Point (Q)</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QPushButton" name="button_remove_point">
        <property name="text">
-        <string>-Point</string>
+        <string>-Point (E)</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
I noticed a few routines while labeling that I covered with shortcuts. One is toggling the 'Auto Use Last Label' option, and the other is switching between adding and removing for SAM auto segmentation.