### PR TITLE
Fix crash when removing points

### DIFF
--- a/anylabeling/views/labeling/label_widget.py
+++ b/anylabeling/views/labeling/label_widget.py
@@ -2397,7 +2397,7 @@ class LabelingWidget(LabelDialog):
     def remove_selected_point(self):
         self.canvas.remove_selected_point()
         self.canvas.update()
-        if not self.canvas.h_hape.points:
+        if self.canvas.h_hape is not None and not self.canvas.h_hape.points:
             self.canvas.delete_shape(self.canvas.h_hape)
             self.remove_labels([self.canvas.h_hape])
             self.set_dirty()


### PR DESCRIPTION
This commit fixes an issue when the user drags a point off the canvas then hits the backspace key to remove the selected point.

Fixes #162