### PR TITLE
Downgrade onnx from 1.16.2 to 1.16.1 

### DIFF
--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -4,7 +4,7 @@ imgviz==1.5.0
 natsort==8.1.0
 termcolor==1.1.0
 PyYAML==6.0.1
-onnx==1.16.2
+onnx==1.16.1
 onnxruntime-gpu==1.18.1
 qimage2ndarray==1.10.0
 darkdetect==0.8.0

--- a/requirements-macos.txt
+++ b/requirements-macos.txt
@@ -4,7 +4,7 @@ imgviz==1.5.0
 natsort==8.1.0
 termcolor==1.1.0
 PyYAML==6.0.1
-onnx==1.16.2
+onnx==1.16.1
 onnxruntime==1.18.1
 qimage2ndarray==1.10.0
 darkdetect==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ imgviz==1.5.0
 natsort==8.1.0
 termcolor==1.1.0
 PyYAML==6.0.1
-onnx==1.16.2
+onnx==1.16.1
 onnxruntime==1.18.1
 qimage2ndarray==1.10.0
 darkdetect==0.8.0

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ def get_install_requires():
         "termcolor==1.1.0",
         "opencv-python-headless==4.7.0.72",
         'PyQt5>=5.15.7; platform_system != "Darwin"',
-        "onnx==1.16.2",
+        "onnx==1.16.1",
         "qimage2ndarray==1.10.0",
         "darkdetect==0.8.0",
     ]


### PR DESCRIPTION
- ImportError: DLL load failed while importing onnx_cpp2py_export: A dynamic link library (DLL) initialization routine failed. 

- Observe this behaviour in windows11 the rootcause is onnx version downgrade to onnx==1.16.1 fix this issue. 