### PR TITLE
fix `TypeError` when drawing text and repeated drawText()

### DIFF
--- a/anylabeling/views/labeling/widgets/canvas.py
+++ b/anylabeling/views/labeling/widgets/canvas.py
@@ -830,16 +830,11 @@ class Canvas(QtWidgets.QWidget):  # pylint: disable=too-many-public-methods, too
                     fm = QtGui.QFontMetrics(p.font())
                     rect = fm.boundingRect(text)
                     p.fillRect(
-                        rect.x() + bbox.x() - 3,
-                        rect.y() + bbox.y() - 3,
+                        int(rect.x() + bbox.x() - 3),
+                        int(rect.y() + bbox.y() - 3),
                         rect.width(),
                         rect.height(),
                         QtGui.QColor("#00FF00"),
-                    )
-                    p.drawText(
-                        bbox.x(),
-                        bbox.y(),
-                        text,
                     )
             pen = QtGui.QPen(QtGui.QColor("#000000"), 8, Qt.SolidLine)
             p.setPen(pen)
@@ -848,8 +843,8 @@ class Canvas(QtWidgets.QWidget):  # pylint: disable=too-many-public-methods, too
                 if text:
                     bbox = shape.bounding_rect()
                     p.drawText(
-                        bbox.x(),
-                        bbox.y(),
+                        int(bbox.x()),
+                        int(bbox.y()),
                         text,
                     )
 


### PR DESCRIPTION
fillRect() parameter x and y needs `float` type.